### PR TITLE
[Experimental] Implement live update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ and `bazaar`.
 ## Requirements
 
 * Emacs 24 or higher
-* [Git](http://git-scm.com/) 1.7.0 or higher
-* [Mercurial](http://mercurial.selenic.com/)
-* [Bazaar](http://bazaar.canonical.com/)
+* [Git](http://git-scm.com/)(1.7.0 or higher) or [Mercurial](http://mercurial.selenic.com/) or [Bazaar](http://bazaar.canonical.com/)
 
 
 ## git-gutter.el vs [git-gutter-fringe.el](https://github.com/syohex/emacs-git-gutter-fringe)
@@ -143,6 +141,16 @@ Update git-gutter information of buffers in all visible window.
 
 
 ## Customize
+
+### Live updating
+
+If you set `git-gutter:update-interval` seconds larger than 0, `git-gutter` updates
+diff information in real-time by idle timer.
+
+```lisp
+(custom-set-variables
+ '(git-gutter:update-interval 2))
+```
 
 ### Look and feel
 

--- a/git-gutter.el
+++ b/git-gutter.el
@@ -1,6 +1,6 @@
 ;;; git-gutter.el --- Port of Sublime Text plugin GitGutter -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2014 by Syohei YOSHIDA
+;; Copyright (C) 2015 by Syohei YOSHIDA
 
 ;; Author: Syohei YOSHIDA <syohex@gmail.com>
 ;; URL: https://github.com/syohex/emacs-git-gutter
@@ -178,6 +178,11 @@ gutter information of other windows."
   :type 'hook
   :group 'git-gutter)
 
+(defcustom git-gutter:update-interval 0
+  "Time interval in seconds for updating diff information."
+  :type 'integer
+  :group 'git-gutter)
+
 (defvar git-gutter:enabled nil)
 (defvar git-gutter:toggle-flag t)
 (defvar git-gutter:force nil)
@@ -189,6 +194,7 @@ gutter information of other windows."
 (defvar git-gutter:vcs-type nil)
 (defvar git-gutter:start-revision nil)
 (defvar git-gutter:revision-history nil)
+(defvar git-gutter:update-timer nil)
 
 (defvar git-gutter:popup-buffer "*git-gutter:diff*")
 (defvar git-gutter:ignore-commands
@@ -260,26 +266,26 @@ gutter information of other windows."
         (goto-char (point-max)))
       (buffer-substring curpoint (point)))))
 
-(defun git-gutter:process-diff-output (proc)
-  (when (buffer-live-p (process-buffer proc))
-    (let ((regexp "^@@ -\\(?:[0-9]+\\),?\\([0-9]*\\) \\+\\([0-9]+\\),?\\([0-9]*\\) @@"))
-      (with-current-buffer (process-buffer proc)
-        (goto-char (point-min))
-        (cl-loop while (re-search-forward regexp nil t)
-                 for new-line  = (string-to-number (match-string 2))
-                 for orig-changes = (git-gutter:changes-to-number (match-string 1))
-                 for new-changes = (git-gutter:changes-to-number (match-string 3))
-                 for type = (cond ((zerop orig-changes) 'added)
-                                  ((zerop new-changes) 'deleted)
-                                  (t 'modified))
-                 for end-line = (if (eq type 'deleted)
-                                    new-line
-                                  (1- (+ new-line new-changes)))
-                 for content = (git-gutter:diff-content)
-                 collect
-                 (let ((start (if (zerop new-line) 1 new-line))
-                       (end (if (zerop end-line) 1 end-line)))
-                   (git-gutter:make-diffinfo type content start end)))))))
+(defun git-gutter:process-diff-output (buf)
+  (when (buffer-live-p buf)
+    (with-current-buffer buf
+      (goto-char (point-min))
+      (cl-loop with regexp = "^@@ -\\(?:[0-9]+\\),?\\([0-9]*\\) \\+\\([0-9]+\\),?\\([0-9]*\\) @@"
+               while (re-search-forward regexp nil t)
+               for new-line  = (string-to-number (match-string 2))
+               for orig-changes = (git-gutter:changes-to-number (match-string 1))
+               for new-changes = (git-gutter:changes-to-number (match-string 3))
+               for type = (cond ((zerop orig-changes) 'added)
+                                ((zerop new-changes) 'deleted)
+                                (t 'modified))
+               for end-line = (if (eq type 'deleted)
+                                  new-line
+                                (1- (+ new-line new-changes)))
+               for content = (git-gutter:diff-content)
+               collect
+               (let ((start (if (zerop new-line) 1 new-line))
+                     (end (if (zerop end-line) 1 end-line)))
+                 (git-gutter:make-diffinfo type content start end))))))
 
 (defsubst git-gutter:window-margin ()
   (or git-gutter:window-width (git-gutter:longest-sign-width)))
@@ -350,7 +356,7 @@ gutter information of other windows."
      (lambda (proc _event)
        (when (eq (process-status proc) 'exit)
          (setq git-gutter:enabled nil)
-         (let ((diffinfos (git-gutter:process-diff-output proc)))
+         (let ((diffinfos (git-gutter:process-diff-output (process-buffer proc))))
            (when (buffer-live-p curbuf)
              (with-current-buffer curbuf
                (git-gutter:update-diffinfo diffinfos)
@@ -547,7 +553,10 @@ gutter information of other windows."
 (defun git-gutter--turn-on ()
   (when (and (buffer-file-name)
              (not (memq major-mode git-gutter:disabled-modes)))
-    (git-gutter-mode +1)))
+    (git-gutter-mode +1)
+    (when (and (not git-gutter:update-timer) (> git-gutter:update-interval 0))
+      (setq git-gutter:update-timer
+            (run-with-idle-timer 1 git-gutter:update-interval 'git-gutter:live-update)))))
 
 ;;;###autoload
 (define-global-minor-mode global-git-gutter-mode git-gutter-mode git-gutter--turn-on
@@ -904,6 +913,70 @@ start revision."
       (with-current-buffer buf
         (when git-gutter-mode
           (git-gutter))))))
+
+(defun git-gutter:start-update-timer ()
+  (interactive)
+  (when git-gutter:update-timer
+    (error "Update timer is already running."))
+  (setq git-gutter:update-timer
+        (run-with-idle-timer 1 git-gutter:update-interval 'git-gutter:live-update)))
+
+(defun git-gutter:cancel-update-timer ()
+  (interactive)
+  (cancel-timer git-gutter:update-timer)
+  (setq git-gutter:update-timer nil))
+
+(defsubst git-gutter:write-current-content (tmpfile)
+  (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+    (with-temp-file tmpfile
+      (insert content))))
+
+(defsubst git-gutter:original-file-content (file)
+  (with-temp-buffer
+    (when (zerop (process-file "git" nil t nil "show" (concat ":" file)))
+      (buffer-substring-no-properties (point-min) (point-max)))))
+
+(defun git-gutter:write-original-content (tmpfile filename)
+  (let ((content (git-gutter:original-file-content filename)))
+    (with-temp-file tmpfile
+      (insert content))))
+
+(defsubst git-gutter:start-raw-diff-process (proc-buf original now)
+  (start-file-process "git-gutter:update-timer" proc-buf
+                      "diff" "-U0" original now))
+
+(defun git-gutter:start-live-update (file original now)
+  (let ((proc-bufname (git-gutter:diff-process-buffer file)))
+    (when (get-buffer proc-bufname)
+      (kill-buffer proc-bufname))
+    (let* ((curbuf (current-buffer))
+           (proc-buf (get-buffer-create proc-bufname))
+           (process (git-gutter:start-raw-diff-process proc-buf original now)))
+      (set-process-query-on-exit-flag process nil)
+      (set-process-sentinel
+       process
+       (lambda (proc _event)
+         (when (eq (process-status proc) 'exit)
+           (setq git-gutter:enabled nil)
+           (let ((diffinfos (git-gutter:process-diff-output (process-buffer proc))))
+             (when (buffer-live-p curbuf)
+               (with-current-buffer curbuf
+                 (git-gutter:update-diffinfo diffinfos)
+                 (setq git-gutter:enabled t)))
+             (kill-buffer proc-buf)
+             (delete-file original)
+             (delete-file now))))))))
+
+(defun git-gutter:live-update ()
+  (if (not global-git-gutter-mode)
+      (git-gutter:cancel-update-timer)
+    (when (and git-gutter:enabled (buffer-modified-p))
+      (let ((file (file-name-nondirectory (git-gutter:base-file)))
+            (now (make-temp-file "git-gutter-cur"))
+            (original (make-temp-file "git-gutter-orig")))
+        (git-gutter:write-original-content original file)
+        (git-gutter:write-current-content now)
+        (git-gutter:start-live-update file original now)))))
 
 ;; for linum-user
 (when (and global-linum-mode (not (boundp 'git-gutter-fringe)))


### PR DESCRIPTION
We can update diff information without saving buffer, reverting buffer etc.

```lisp
(custom-set-variables
 '(git-gutter:update-interval 2))
```

![git-gutter-live-update](https://cloud.githubusercontent.com/assets/554281/6667801/c820a54c-cc31-11e4-86d6-ca136d67181a.gif)
