### PR TITLE
use relative path when svn through windows emacs

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -917,7 +917,7 @@ gutter information of other windows."
                                             "rev-parse" "--quiet" "--verify"
                                             revision))
            (svn (git-gutter:execute-command "svn" nil "info" "-r" revision
-                                            (buffer-file-name)))
+                                            (file-relative-name (buffer-file-name))))
            (hg (git-gutter:execute-command "hg" nil "id" "-r" revision))
            (bzr (git-gutter:execute-command "bzr" nil
                                             "revno" "-r" revision)))))


### PR DESCRIPTION
Windows Emacs use path "C:/users/proj1/test.js".

Cygwin subversion don't recognize this kind of path.

But relative path like test.js always works.

tested on Windows Emacs 24.4, latest cygwin svn 1.8.11