### PR TITLE
Add utilities of counting unstaged hunks

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -988,6 +988,19 @@ start revision."
 (when (and global-linum-mode (not (boundp 'git-gutter-fringe)))
   (git-gutter:linum-setup))
 
+(defun git-gutter:all-hunks ()
+  "Cound unstaged hunks in all buffers"
+  (let ((sum 0))
+    (dolist (buf (buffer-list))
+      (with-current-buffer buf
+        (when git-gutter-mode
+          (cl-incf sum (git-gutter:buffer-hunks)))))
+    sum))
+
+(defun git-gutter:buffer-hunks ()
+  "Count unstaged hunks in current buffer."
+  (length git-gutter:diffinfos))
+
 (provide 'git-gutter)
 
 ;;; git-gutter.el ends here


### PR DESCRIPTION
I suppose this is useful for mode-line customization.

![count-hunk](https://cloud.githubusercontent.com/assets/554281/12755821/5fa6985a-ca14-11e5-91ba-0597f5bff248.png)

Unstaged hunks(=3) and hunks of all buffer(=6) is displayed on mode-line. We can know there are too many changes and commit timing from them.

`mode-line` configuration sample is here.

```lisp
(defface my/vc-branch
  '((t (:foreground "red" :weight bold)))
  "Branch information in mode-line"
  :group 'my)

(defvar my/vc-mode-line
  '(:propertize
    (:eval (let* ((file (buffer-file-name))
                  (backend (symbol-name (vc-backend file)))
                  (branch (substring vc-mode (+ (length backend) 2)))
                  (state (cl-case (vc-state file)
                           (edited
                            (format ":%d" (git-gutter:buffer-hunks)))
                           (otherwise ""))))
             (format "(%s%s[%d])"
                     branch state (git-gutter:all-hunks))))
    face my/vc-branch)
  "Mode line format for VC Mode.")
(put 'my/vc-mode-line 'risky-local-variable t)

(setq-default mode-line-format
              '("%e"
                mode-line-front-space
                mode-line-mule-info
                mode-line-client
                mode-line-modified
                mode-line-remote
                mode-line-frame-identification
                mode-line-buffer-identification " " mode-line-position
                (vc-mode my/vc-mode-line)
                " "
                mode-line-modes mode-line-misc-info mode-line-end-spaces))
```