### PR TITLE
Support putting sign at gutter by visual lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,19 @@ to `non-nil`.
 
 Default is `nil`.
 
+### Show signs at gutter by visual lines
+
+Emacs folds long line if `truncate-lines` is `nil`. If `git-gutter:visual-line` is
+non-nil, `git-gutter` puts sign by visual lines.
+
+```lisp
+(custom-set-variables
+ '(git-gutter:visual-line t))
+```
+
+Default bahavior is that signs are put by logical lines.
+value of `git-gutter:visual-line` is `nil`.
+
 ### Show Unchanged Information
 
 ![git-gutter-unchanged](image/git-gutter-unchanged.png)


### PR DESCRIPTION
This is related to #121.
CC: @ErkiDerLoony

#### `git-gutter:visual-line` is `nil(Default behaviour)

![logical-line](https://cloud.githubusercontent.com/assets/554281/14318950/2c637586-fc4a-11e5-9c50-84e8e5b1c967.png)

#### `git-gutter:visual-line` is non-nil

![visual-line](https://cloud.githubusercontent.com/assets/554281/14318963/3a0d77f4-fc4a-11e5-9f0d-a07b36f87d3d.png)

