### PR TITLE
Add display flag

### DIFF
--- a/git-gutter.el
+++ b/git-gutter.el
@@ -169,6 +169,10 @@ gutter information of other windows."
   "Ask whether commit/revert or not"
   :type 'boolean)
 
+(defcustom git-gutter:display-p t
+  "Display diff information or not."
+  :type 'boolean)
+
 (cl-defstruct git-gutter-hunk
   type content start-line end-line)
 
@@ -508,12 +512,13 @@ gutter information of other windows."
   (setq git-gutter:init-function 'git-gutter:linum-init
         git-gutter:view-diff-function nil)
   (defadvice linum-update-window (after git-gutter:linum-update-window activate)
-    (if (and git-gutter-mode git-gutter:diffinfos)
-        (git-gutter:linum-update git-gutter:diffinfos)
-      (let ((curwin (get-buffer-window))
-            (margin (or git-gutter:linum-prev-window-margin
-                        (car (window-margins)))))
-        (set-window-margins curwin margin (cdr (window-margins curwin)))))))
+    (when git-gutter:display-p
+      (if (and git-gutter-mode git-gutter:diffinfos)
+          (git-gutter:linum-update git-gutter:diffinfos)
+        (let ((curwin (get-buffer-window))
+              (margin (or git-gutter:linum-prev-window-margin
+                          (car (window-margins)))))
+          (set-window-margins curwin margin (cdr (window-margins curwin))))))))
 
 (defun git-gutter:show-backends ()
   (mapconcat (lambda (backend)
@@ -630,7 +635,7 @@ gutter information of other windows."
     (widen)
     (git-gutter:clear-gutter)
     (setq git-gutter:diffinfos diffinfos)
-    (when git-gutter:view-diff-function
+    (when (and git-gutter:display-p git-gutter:view-diff-function)
       (funcall git-gutter:view-diff-function diffinfos))))
 
 (defun git-gutter:search-near-diff-index (diffinfos is-reverse)


### PR DESCRIPTION
When this flag is nil, git-gutter.el does not display diff info in gutter,
however git-gutter commands, moving to next/previous hunk etc, works.

This is related to #124.
See https://github.com/syohex/emacs-git-gutter/issues/124#issuecomment-227099817